### PR TITLE
Fix error ModuleNotFoundError: No module named 'six'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 docker
 python-pushover
+six


### PR DESCRIPTION
Later versions of python, etc. need "six" to be included in the pip requirements.